### PR TITLE
Rewrite in pure Javascript

### DIFF
--- a/appendAround.js
+++ b/appendAround.js
@@ -1,42 +1,40 @@
-/*! appendAround markup pattern. [c]2012, @scottjehl, Filament Group, Inc. MIT/GPL 
-how-to:
-	1. Insert potential element containers throughout the DOM
-	2. give each container a data-set attribute with a value that matches all other containers' values
-	3. Place your appendAround content in one of the potential containers
-	4. Call appendAround() on that element when the DOM is ready
-*/
-(function( $ ){
-	$.fn.appendAround = function(){
-	  return this.each(function(){
-      
-	    var $self = $( this ),
-	        att = "data-set",
-	        $parent = $self.parent(), 
-	        parent = $parent[ 0 ],
-	        attval = $parent.attr( att ),
-	        $set = $( "["+ att +"='" + attval + "']" );
+/*! appendAround markup pattern. [c]2012, @scottjehl, Filament Group, Inc. MIT/GPL
+  how-to:
+  1. Insert potential element containers throughout the DOM
+  2. give each container a data-set attribute with a value that matches all other containers' values
+  3. Place your appendAround content in one of the potential containers
+  4. Call appendAround() on that element when the DOM is ready
+  */
+(function(global) {
+	global.appendAround = function(selector) {
+		var elems, current, parent, att, attval, set;
 
-		function isHidden( elem ){
-			return window.getComputedStyle( elem ,null).getPropertyValue( "display" ) === "none";
+		function isHidden(elem) {
+			return window.getComputedStyle(elem, null).getPropertyValue('display') === 'none';
 		}
 
-		function appendToVisibleContainer(){
-			if( isHidden( parent ) ){
-				var found = 0;
-				$set.each(function(){
-					if( !isHidden( this ) && !found ){
-						$self.appendTo( this );
-						found++;
-						parent = this;
+		function appendToVisibleContainer() {
+			if ( isHidden(parent) ) {
+				for ( var i = 0; i < set.length; i++ ) {
+					if ( !isHidden(set[i]) ) {
+						parent = set[i];
+						parent.appendChild(current);
+						break;
 					}
-				});
-	      	}
-	    }
-      
-	    appendToVisibleContainer();
-      
-	    $(window).bind( "resize", appendToVisibleContainer );
-      
-	  });
+				}
+			}
+		}
+
+		elems = document.querySelectorAll(selector);
+		for ( var i = 0; i < elems.length; i++ ) {
+			current = elems[i];
+			parent = current.parentNode;
+			att = 'data-set';
+			attval = parent.getAttribute(att);
+			set = document.querySelectorAll('[' + att + '=' + attval + ']');
+
+			appendToVisibleContainer();
+			window.addEventListener('resize', appendToVisibleContainer);
+		}
 	};
-}( jQuery ));
+})(window);

--- a/index.html
+++ b/index.html
@@ -62,11 +62,10 @@
 	   <li>Vestibulum auctor dapibus neque.</li>
 	</ul>
 
- <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
  <script src="appendAround.js"></script>
  <script>
 	/* Call appendAround */
-	$( ".sample" ).appendAround();
+	appendAround('.sample');
 </script>
 </body>
 </html>


### PR DESCRIPTION
I opened ticket #5, which converts this into being a pure jQuery plugin, before seeing the commit in which you cleared things up to be less reliant on jQuery.

This branch removes any reliance on jQuery entirely, allowing it to be embedded in any page; the only dependency is the DOM, and specifically the `document.querySelectorAll` method — but since we're relying on media queries, I think we can also safely rely on that.

As a result, the call changes from $.appendAround('foo') to appendAround('foo'); I've updated the example HTML to reflect that too.
