### PR TITLE
feat: replace getComputedStyle with .css for < IE9 support.

### DIFF
--- a/appendAround.js
+++ b/appendAround.js
@@ -17,7 +17,7 @@ how-to:
 	        $set = $( "["+ att +"='" + attval + "']" );
 
 		function isHidden( elem ){
-			return window.getComputedStyle( elem ,null).getPropertyValue( "display" ) === "none";
+			return $(elem).css( "display" ) === "none";
 		}
 
 		function appendToVisibleContainer(){


### PR DESCRIPTION
I replaced `getComputedStyle` with the jQuery `.css` method to support old IE.
