### PR TITLE
check whether or not the parent is visible

### DIFF
--- a/appendAround.js
+++ b/appendAround.js
@@ -17,7 +17,7 @@ how-to:
 	        $set = $( "["+ att +"='" + attval + "']" );
 
 		function isHidden( elem ){
-			return $(elem).css( "display" ) === "none";
+			return $(elem).is( ":hidden" );
 		}
 
 		function appendToVisibleContainer(){


### PR DESCRIPTION
checking if the direct parent with the data attribute is visible instead of whether it has explicitly been set a "display: none;" allows for this to work with less code when you are hiding and displaying an indirect parent ancestor element with several child elements that may be containers using appendAround.
